### PR TITLE
Phase 5 — Observability + opt-in IA externe

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ npm run test             # Run tests
 npm run test:rust        # Cargo tests
 ```
 
+### External AI (opt-in, local-first par défaut)
+
+Par défaut, TITANE∞ est **local-only** (aucun cloud requis) et les providers externes sont **désactivés**.
+
+- **Autoriser au build (dev/stable)** : lancer avec `VITE_ENABLE_EXTERNAL_AI=1`
+	- Exemple dev : `VITE_ENABLE_EXTERNAL_AI=1 npm run dev:tauri`
+- **Activer au runtime (production uniquement)** : `localStorage.setItem('titane.enable_external_ai','1')`
+	- Désactiver : `localStorage.removeItem('titane.enable_external_ai')`
+
+Notes :
+- En **dev**, l’activation runtime est implicitement autorisée si le build flag est présent.
+- En **stable**, l’External AI reste off tant que le build flag et le runtime toggle ne sont pas tous les deux activés.
+
 ### Git Workflow
 
 ```

--- a/check_api_status.js
+++ b/check_api_status.js
@@ -47,9 +47,9 @@ console.log('   OpenAI: https://platform.openai.com (API Keys section)');
 console.log('   Anthropic: https://console.anthropic.com (API Keys)');
 
 console.log('\n⚙️ Feature Flags (src/config/featureFlags.ts):');
-console.log('   ENABLE_EXTERNAL_AI: false ⚠️ (needs to be TRUE)');
-console.log('   AI_PROVIDERS.gemini: false ⚠️ (needs to be TRUE)');
-console.log('   AI_PROVIDERS.openai: false ⚠️ (needs to be TRUE)');
+console.log('   ENABLE_EXTERNAL_AI: false ✅ (default local-first)');
+console.log('   AI_PROVIDERS.gemini: false ✅ (default local-first)');
+console.log('   AI_PROVIDERS.openai: false ✅ (default local-first)');
 console.log('   AI_PROVIDERS.ollama: true ✅');
 
 console.log('\n═══════════════════════════════════════════════════════════');
@@ -62,7 +62,7 @@ if (!geminiKey && !openaiKey && !anthropicKey) {
   console.log('   1️⃣  MÉTHODE .ENV (Développement rapide):');
   console.log('      - Copier .env.example → .env');
   console.log('      - Remplir GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY');
-  console.log('      - Redémarrer le serveur\n');
+  console.log('      - Relancer Titan-Dev (npm run dev:tauri)\n');
 
   console.log('   2️⃣  MÉTHODE SÉCURISÉE (Production recommandée):');
   console.log('      - Ouvrir TITANE∞ → Governance Center');
@@ -70,8 +70,7 @@ if (!geminiKey && !openaiKey && !anthropicKey) {
   console.log('      - Les clés seront chiffrées (AES-256-GCM)\n');
 
   console.log('   3️⃣  MÉTHODE CONSOLE NAVIGATEUR:');
-  console.log('      - Ouvrir http://localhost:5173/');
-  console.log('      - Ouvrir la console (F12)');
+  console.log('      - Ouvrir la console DevTools (si disponible)');
   console.log('      - Exécuter:');
   console.log(
     "         window.__TAURI_INTERNALS__.invoke('chat_set_gemini_key', {apiKey: 'votre_cle'})"
@@ -90,14 +89,9 @@ if (!geminiKey && !openaiKey && !anthropicKey) {
   console.log('   - Utiliser chat_set_*_key() pour la migration\n');
 }
 
-console.log('📝 ÉTAPE CRITIQUE: Activer les feature flags');
-console.log('   Fichier: src/config/featureFlags.ts');
-console.log('   Modifier:');
-console.log('      ENABLE_EXTERNAL_AI: true,');
-console.log('      AI_PROVIDERS: {');
-console.log('        gemini: true,');
-console.log('        openai: true,');
-console.log('        ollama: true,');
-console.log('      }\n');
+console.log('📝 ÉTAPE CRITIQUE: Activer External AI (opt-in)');
+console.log('   Guardrails (recommandé):');
+console.log('      1) Build flag: VITE_ENABLE_EXTERNAL_AI=1');
+console.log("      2) Runtime (prod uniquement): localStorage.setItem('titane.enable_external_ai','1')\n");
 
 console.log('═══════════════════════════════════════════════════════════\n');

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -6,6 +6,39 @@
  * Mode par défaut: 100% LOCAL (production-ready)
  */
 
+type EnvValue = string | boolean | undefined;
+
+const env = import.meta.env as Record<string, EnvValue>;
+
+function envFlag(key: string): boolean {
+  const value = env[key];
+  if (value === true) return true;
+  if (value === false) return false;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === '1' || normalized === 'true' || normalized === 'yes';
+  }
+  return false;
+}
+
+function runtimeFlag(key: string): boolean {
+  try {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
+
+// Guardrails:
+// - Build-time allow: VITE_ENABLE_EXTERNAL_AI=1
+// - Runtime toggle (no rebuild): localStorage.setItem('titane.enable_external_ai', '1')
+//   (default off in production)
+const buildAllowsExternalAI = envFlag('VITE_ENABLE_EXTERNAL_AI');
+const runtimeAllowsExternalAI =
+  import.meta.env.DEV ? true : runtimeFlag('titane.enable_external_ai');
+const externalAIEnabled = buildAllowsExternalAI && runtimeAllowsExternalAI;
+
 export const FEATURE_FLAGS = {
   /**
    * 🔒 NETWORK ACCESS (DEFAULT: DISABLED)
@@ -13,7 +46,7 @@ export const FEATURE_FLAGS = {
    * Enable external network calls (AI APIs, etc.)
    * WARNING: Requires internet connection
    */
-  ENABLE_EXTERNAL_AI: true, // Gemini, OpenAI APIs ✅ ENABLED
+  ENABLE_EXTERNAL_AI: externalAIEnabled, // External AI gated by build + runtime
   ENABLE_LOCAL_LLM: true, // Ollama localhost (optional)
 
   /**
@@ -21,8 +54,8 @@ export const FEATURE_FLAGS = {
    * ═══════════════════════════════════════
    */
   AI_PROVIDERS: {
-    gemini: true, // Google Gemini API (requires API key) ✅ ENABLED
-    openai: true, // OpenAI API (requires API key) ✅ ENABLED
+    gemini: externalAIEnabled, // Google Gemini API (requires API key)
+    openai: externalAIEnabled, // OpenAI API (requires API key)
     ollama: true, // Local Ollama (optional, localhost:11434)
     builtin: true, // Built-in mock responses (always available)
   },

--- a/src/features/qa-monitoring/QAMonitoringPage.tsx
+++ b/src/features/qa-monitoring/QAMonitoringPage.tsx
@@ -22,6 +22,7 @@ import type {
   PerformanceReport,
   LogEntry,
 } from './types';
+import monitoring, { type PerformanceMetrics } from '@/monitoring';
 import './QAMonitoringPage.css';
 
 // ============================================================================
@@ -82,25 +83,47 @@ StatusBadge.displayName = 'StatusBadge';
 interface OverviewTabProps {
   state: QASystemState | null;
   metrics: SystemMetrics | null;
+  frontendMetrics: PerformanceMetrics | null;
   alerts: Alert[];
   onRefresh: () => void;
+  onExportFrontendMetrics: () => void;
 }
 
 const OverviewTab = ({
   state,
   metrics,
+  frontendMetrics,
   alerts,
   onRefresh,
+  onExportFrontendMetrics,
 }: OverviewTabProps): JSX.Element => {
   const activeAlerts = alerts.filter(a => !a.resolved);
+
+  const formatMs = (value: number | undefined): string =>
+    typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(0)}ms` : '—';
+
+  const formatRate = (value: number | undefined): string =>
+    typeof value === 'number' && Number.isFinite(value)
+      ? `${(value * 100).toFixed(2)}%`
+      : '—';
+
+  const formatBytesAsMB = (value: number | undefined): string =>
+    typeof value === 'number' && Number.isFinite(value)
+      ? `${(value / 1024 / 1024).toFixed(1)}MB`
+      : '—';
 
   return (
     <div className="qa-tab-content">
       <div className="qa-section-header">
         <h2>🎯 Vue d&apos;ensemble QA</h2>
-        <button className="qa-btn qa-btn--primary" onClick={onRefresh}>
-          🔄 Rafraîchir
-        </button>
+        <div className="qa-actions">
+          <button className="qa-btn qa-btn--secondary" onClick={onExportFrontendMetrics}>
+            📤 Exporter métriques
+          </button>
+          <button className="qa-btn qa-btn--primary" onClick={onRefresh}>
+            🔄 Rafraîchir
+          </button>
+        </div>
       </div>
 
       {state && (
@@ -199,6 +222,48 @@ const OverviewTab = ({
           </div>
         </div>
       )}
+
+      <div className="qa-metrics-section">
+        <h3>🧭 Observability (frontend)</h3>
+        <div className="qa-stats-grid">
+          <StatCard
+            label="Erreurs"
+            value={frontendMetrics?.errorCount ?? '—'}
+            icon="❌"
+            variant={(frontendMetrics?.errorCount ?? 0) > 0 ? 'warning' : 'success'}
+          />
+          <StatCard
+            label="Error rate"
+            value={formatRate(frontendMetrics?.errorRate)}
+            icon="📉"
+            variant={(frontendMetrics?.errorRate ?? 0) > 0.05 ? 'error' : 'success'}
+          />
+          <StatCard
+            label="Latence pipeline"
+            value={formatMs(frontendMetrics?.pipelineLatency)}
+            icon="⏱️"
+            variant={(frontendMetrics?.pipelineLatency ?? 0) > 200 ? 'warning' : 'success'}
+          />
+          <StatCard
+            label="Erreurs pipeline"
+            value={frontendMetrics?.pipelineErrors ?? '—'}
+            icon="🧯"
+            variant={(frontendMetrics?.pipelineErrors ?? 0) > 0 ? 'warning' : 'success'}
+          />
+          <StatCard
+            label="Mémoire JS"
+            value={formatBytesAsMB(frontendMetrics?.memoryUsage)}
+            icon="🧠"
+            variant="info"
+          />
+          <StatCard
+            label="LCP"
+            value={formatMs(frontendMetrics?.LCP)}
+            icon="🖥️"
+            variant="info"
+          />
+        </div>
+      </div>
 
       {activeAlerts.length > 0 && (
         <div className="qa-alerts-section">
@@ -747,6 +812,9 @@ function QAMonitoringPageContent(): JSX.Element {
   const [activeTab, setActiveTab] = useState<TabId>('overview');
   const [state, setState] = useState<QASystemState | null>(null);
   const [metrics, setMetrics] = useState<SystemMetrics | null>(null);
+  const [frontendMetrics, setFrontendMetrics] = useState<PerformanceMetrics | null>(
+    null
+  );
   const [suites, setSuites] = useState<TestSuite[]>([]);
   const [testResults, setTestResults] = useState<TestResult[]>([]);
   const [monitors, setMonitors] = useState<Monitor[]>([]);
@@ -807,6 +875,24 @@ function QAMonitoringPageContent(): JSX.Element {
       setLoading(false);
     }
   }, [qa, showResolvedAlerts, perfPeriod]);
+
+  useEffect(() => {
+    try {
+      setFrontendMetrics(monitoring.getMetrics());
+    } catch {
+      // noop
+    }
+
+    const interval = window.setInterval(() => {
+      try {
+        setFrontendMetrics(monitoring.getMetrics());
+      } catch {
+        // noop
+      }
+    }, 2000);
+
+    return () => window.clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     loadData();
@@ -915,6 +1001,27 @@ function QAMonitoringPageContent(): JSX.Element {
     }
   };
 
+  const handleExportFrontendMetrics = useCallback(() => {
+    try {
+      const json = monitoring.exportMetrics();
+      const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `titane-metrics-${new Date().toISOString()}.json`;
+      a.click();
+
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      logger.error(
+        'Failed to export frontend metrics',
+        { component: 'QAMonitoringPage', action: 'exportFrontendMetrics' },
+        err as Error
+      );
+    }
+  }, []);
+
   // Render
   if (loading || matrixLoading) {
     return (
@@ -975,8 +1082,10 @@ function QAMonitoringPageContent(): JSX.Element {
           <OverviewTab
             state={state}
             metrics={metrics}
+            frontendMetrics={frontendMetrics}
             alerts={alerts}
             onRefresh={loadData}
+            onExportFrontendMetrics={handleExportFrontendMetrics}
           />
         )}
         {activeTab === 'tests' && (

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -9,6 +9,7 @@
  */
 
 import { safeInvokeTauri } from '@/utils/tauriProtector';
+import monitoring from '@/monitoring';
 
 // ────────────────────────────────────────────────────────────────
 // Constants
@@ -1621,12 +1622,34 @@ export async function secureInvoke<T>(
     treatFallbackAsError = false,
   } = options;
 
+  const startedAt = Date.now();
+  try {
+    monitoring.trackRequest();
+    monitoring.addBreadcrumb('secureInvoke start', 'tauri', {
+      command,
+      hasPayload: payload && Object.keys(payload).length > 0,
+      payloadKeysCount: payload ? Object.keys(payload).length : 0,
+    });
+  } catch {
+    // ignore monitoring errors
+  }
+
   // [1] Validation commande whitelist
   if (!skipWhitelistCheck) {
     const cmdValidation = validateCommand(command);
     if (!cmdValidation.valid) {
       const errorMsg = `Security: ${cmdValidation.errors.join('; ')}`;
       console.error(`[Security] ✗ ${errorMsg}`);
+
+      try {
+        monitoring.trackError(new Error(errorMsg), {
+          command,
+          stage: 'validateCommand',
+        });
+      } catch {
+        // ignore monitoring errors
+      }
+
       throw new Error(errorMsg);
     }
   }
@@ -1637,6 +1660,16 @@ export async function secureInvoke<T>(
     if (!injectionCheck.valid) {
       const errorMsg = `Security: ${injectionCheck.errors.join('; ')}`;
       console.error(`[Security] ✗ ${errorMsg}`);
+
+      try {
+        monitoring.trackError(new Error(errorMsg), {
+          command,
+          stage: 'detectInjection',
+        });
+      } catch {
+        // ignore monitoring errors
+      }
+
       throw new Error(errorMsg);
     }
   }
@@ -1646,6 +1679,16 @@ export async function secureInvoke<T>(
   if (!sizeCheck.valid) {
     const errorMsg = `Security: ${sizeCheck.errors.join('; ')}`;
     console.error(`[Security] ✗ ${errorMsg}`);
+
+    try {
+      monitoring.trackError(new Error(errorMsg), {
+        command,
+        stage: 'validatePayloadSize',
+      });
+    } catch {
+      // ignore monitoring errors
+    }
+
     throw new Error(errorMsg);
   }
 
@@ -1655,6 +1698,16 @@ export async function secureInvoke<T>(
     if (!loopCheck.valid) {
       const errorMsg = `Security: ${loopCheck.errors.join('; ')}`;
       console.error(`[Security] ✗ ${errorMsg}`);
+
+      try {
+        monitoring.trackError(new Error(errorMsg), {
+          command,
+          stage: 'detectInfiniteLoop',
+        });
+      } catch {
+        // ignore monitoring errors
+      }
+
       throw new Error(errorMsg);
     }
   }
@@ -1726,11 +1779,32 @@ export async function secureInvoke<T>(
       throw new Error('Fallback response received');
     }
 
+      try {
+        monitoring.addBreadcrumb('secureInvoke success', 'tauri', {
+          command,
+          latencyMs: Date.now() - startedAt,
+        });
+      } catch {
+        // ignore monitoring errors
+      }
+
     return sanitized as T;
   } catch (error) {
     // Log et re-throw
     const errorMsg = error instanceof Error ? error.message : String(error);
     console.error(`[Security] ✗ secureInvoke("${command}") failed:`, errorMsg);
+
+      try {
+        const err = error instanceof Error ? error : new Error(String(error));
+        monitoring.trackError(err, {
+          command,
+          stage: 'invoke',
+          latencyMs: Date.now() - startedAt,
+        });
+      } catch {
+        // ignore monitoring errors
+      }
+
     throw error;
   }
 }

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1794,16 +1794,16 @@ export async function secureInvoke<T>(
     const errorMsg = error instanceof Error ? error.message : String(error);
     console.error(`[Security] ✗ secureInvoke("${command}") failed:`, errorMsg);
 
-      try {
-        const err = error instanceof Error ? error : new Error(String(error));
-        monitoring.trackError(err, {
-          command,
-          stage: 'invoke',
-          latencyMs: Date.now() - startedAt,
-        });
-      } catch {
-        // ignore monitoring errors
-      }
+    try {
+      const err = error instanceof Error ? error : new Error(String(error));
+      monitoring.trackError(err, {
+        command,
+        stage: 'invoke',
+        latencyMs: Date.now() - startedAt,
+      });
+    } catch {
+      // ignore monitoring errors
+    }
 
     throw error;
   }

--- a/src/services/api/chat.ts
+++ b/src/services/api/chat.ts
@@ -290,7 +290,19 @@ class ChatService {
     config?: StreamConfig
   ): Promise<ChatResponse> {
     this.lastEndpoint = 'LEGACY';
+    const startedAt = Date.now();
+    monitoring.trackRequest();
+
     const request = this.buildRequest(messages, config, false);
+
+    const lastMessage = messages[messages.length - 1]?.content ?? '';
+    monitoring.addBreadcrumb('Chat sendMessage (LEGACY)', 'chat', {
+      endpoint: 'LEGACY',
+      provider: config?.provider ?? 'auto',
+      mode: config?.mode,
+      messageCount: messages.length,
+      messageLength: lastMessage.length,
+    });
 
     console.log('[ChatService] 📤 Envoi message:', {
       provider: config?.provider ?? 'auto',
@@ -305,6 +317,16 @@ class ChatService {
         { ...LONG_COMMAND_OPTIONS, context: 'Chat' }
       );
 
+      const backendLatency = this.resolveLatencyMs(backendResponse.latency_ms);
+      const measuredLatency = Date.now() - startedAt;
+      const effectiveLatency = backendLatency > 0 ? backendLatency : measuredLatency;
+      monitoring.trackPipelineLatency(effectiveLatency);
+
+      if (!backendResponse.success || !backendResponse.message) {
+        monitoring.trackPipelineError();
+        throw new Error(backendResponse.error ?? 'Réponse invalide du backend LEGACY');
+      }
+
       console.log('[ChatService] 📥 Réponse reçue:', {
         success: backendResponse.success,
         provider: this.resolveProvider(
@@ -318,6 +340,15 @@ class ChatService {
       return this.normalizeResponse(backendResponse, config);
     } catch (error) {
       console.error('[ChatService] ❌ Erreur sendMessage:', error);
+
+      monitoring.trackError(error, {
+        endpoint: 'LEGACY',
+        provider: config?.provider ?? 'auto',
+        mode: config?.mode,
+        messageCount: messages.length,
+      });
+      monitoring.trackPipelineError();
+
       const reason = error instanceof Error ? error.message : String(error);
       throw new Error(`Chat envoi échoué: ${reason}`);
     }
@@ -333,7 +364,65 @@ class ChatService {
     onError: (error: Error) => void,
     config?: StreamConfig
   ): Promise<void> {
+    this.lastEndpoint = 'LEGACY';
+    const startedAt = Date.now();
+    monitoring.trackRequest();
+
     const request = this.buildRequest(messages, config, true);
+
+    const lastMessage = messages[messages.length - 1]?.content ?? '';
+    monitoring.addBreadcrumb('Chat sendMessageStream (LEGACY)', 'chat', {
+      endpoint: 'LEGACY',
+      streaming: true,
+      provider: config?.provider ?? 'auto',
+      mode: config?.mode,
+      messageCount: messages.length,
+      messageLength: lastMessage.length,
+      conversationId: config?.conversationId,
+      messageId: config?.messageId,
+    });
+
+    const reportStreamError = (err: Error, phase: string) => {
+      try {
+        monitoring.trackError(err, {
+          endpoint: 'LEGACY_STREAM',
+          phase,
+          provider: config?.provider ?? 'auto',
+          mode: config?.mode,
+          messageCount: messages.length,
+          conversationId: config?.conversationId,
+          messageId: config?.messageId,
+        });
+        monitoring.trackPipelineError();
+      } catch {
+        // Intentionally ignore monitoring errors
+      }
+    };
+
+    const reportStreamSuccess = (response: ChatResponse, source: string) => {
+      try {
+        const measuredLatency = Date.now() - startedAt;
+        const responseLatency =
+          typeof response.latencyMs === 'number' && Number.isFinite(response.latencyMs)
+            ? response.latencyMs
+            : 0;
+        const effectiveLatency = responseLatency > 0 ? responseLatency : measuredLatency;
+        monitoring.trackPipelineLatency(effectiveLatency);
+
+        monitoring.addBreadcrumb('Chat stream completed', 'chat', {
+          endpoint: 'LEGACY',
+          source,
+          provider: response.provider ?? (config?.provider ?? 'auto'),
+          mode: config?.mode,
+          latencyMs: effectiveLatency,
+          chunkCount: response.metadata?.chunkCount,
+          conversationId: response.metadata?.conversationId,
+          messageId: response.metadata?.messageId,
+        });
+      } catch {
+        // Intentionally ignore monitoring errors
+      }
+    };
 
     let unlistenChunk: UnlistenFn | null = null;
     let unlistenComplete: UnlistenFn | null = null;
@@ -469,6 +558,7 @@ class ChatService {
           completed = true;
           cleanup();
           const err = new Error(normalized.error);
+          reportStreamError(err, 'complete');
           try {
             onError(err);
           } catch (callbackError) {
@@ -494,6 +584,8 @@ class ChatService {
           targetConversationId ?? normalized.conversationId ?? null,
           targetMessageId ?? normalized.messageId ?? null
         );
+
+        reportStreamSuccess(response, 'event');
 
         try {
           onComplete(response);
@@ -608,6 +700,8 @@ class ChatService {
 
         completed = true;
 
+        reportStreamSuccess(response, 'fallback');
+
         try {
           onComplete(response);
         } catch (callbackError) {
@@ -622,6 +716,7 @@ class ChatService {
     } catch (error) {
       cleanup();
       const err = error instanceof Error ? error : new Error(String(error));
+      reportStreamError(err, 'outer');
       try {
         onError(err);
       } catch (callbackError) {

--- a/src/ui/pages/ControlPanel/sections/AISection.tsx
+++ b/src/ui/pages/ControlPanel/sections/AISection.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { secureInvoke } from '@/lib/security';
+import { ControlPanelToggle } from '../components/ControlPanelToggle';
 
 interface AIConfig {
   gemini_api_key: string;
@@ -14,6 +15,22 @@ interface AIConfig {
 }
 
 const GEMINI_KEY_SENTINEL = '***MASKED***';
+const EXTERNAL_AI_STORAGE_KEY = 'titane.enable_external_ai';
+
+type EnvValue = string | boolean | undefined;
+
+const env = import.meta.env as Record<string, EnvValue>;
+
+function envFlag(key: string): boolean {
+  const value = env[key];
+  if (value === true) return true;
+  if (value === false) return false;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === '1' || normalized === 'true' || normalized === 'yes';
+  }
+  return false;
+}
 
 const DEFAULT_CONFIG: AIConfig = {
   gemini_api_key: '',
@@ -40,6 +57,15 @@ export const AISection: React.FC = () => {
   const [saved, setSaved] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [externalAIRuntimeEnabled, setExternalAIRuntimeEnabled] = useState(false);
+  const [externalAIToggleError, setExternalAIToggleError] = useState<string | null>(
+    null
+  );
+
+  const isDev = import.meta.env.DEV;
+  const buildAllowsExternalAI = useMemo(() => envFlag('VITE_ENABLE_EXTERNAL_AI'), []);
+  const effectiveExternalAIEnabled =
+    buildAllowsExternalAI && (isDev ? true : externalAIRuntimeEnabled);
 
   const runtimeConfig = useMemo<RuntimeConfig | null>(() => {
     if (typeof window === 'undefined') {
@@ -80,6 +106,62 @@ export const AISection: React.FC = () => {
     }
     void loadConfig();
   }, [loadConfig, runtimeConfig?.geminiConfigured]);
+
+  useEffect(() => {
+    try {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      setExternalAIRuntimeEnabled(
+        window.localStorage.getItem(EXTERNAL_AI_STORAGE_KEY) === '1'
+      );
+      setExternalAIToggleError(null);
+    } catch {
+      setExternalAIToggleError(
+        "Impossible d'accéder au stockage local (localStorage)."
+      );
+    }
+  }, []);
+
+  const toggleExternalAI = useCallback(() => {
+    if (!buildAllowsExternalAI) {
+      setExternalAIToggleError(
+        'External AI non autorisée par ce build (VITE_ENABLE_EXTERNAL_AI=1 requis).'
+      );
+      return;
+    }
+
+    try {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const next = !externalAIRuntimeEnabled;
+      if (next) {
+        window.localStorage.setItem(EXTERNAL_AI_STORAGE_KEY, '1');
+      } else {
+        window.localStorage.removeItem(EXTERNAL_AI_STORAGE_KEY);
+      }
+
+      setExternalAIRuntimeEnabled(next);
+      setExternalAIToggleError(null);
+    } catch {
+      setExternalAIToggleError(
+        "Impossible de modifier le stockage local (localStorage)."
+      );
+    }
+  }, [buildAllowsExternalAI, externalAIRuntimeEnabled]);
+
+  const reloadApp = useCallback(() => {
+    try {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      window.location.reload();
+    } catch {
+      setExternalAIToggleError('Impossible de recharger l’application.');
+    }
+  }, []);
 
   const saveConfig = useCallback(async () => {
     try {
@@ -295,6 +377,37 @@ export const AISection: React.FC = () => {
           )}
           {showUnsavedChanges && !validationError && !error && (
             <p className="cp-helper-text">Modifications en attente de sauvegarde.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="cp-card">
+        <h3 className="cp-card-title">External AI (opt-in)</h3>
+        <div className="cp-card-content">
+          <ControlPanelToggle
+            checked={effectiveExternalAIEnabled}
+            onChange={toggleExternalAI}
+            title="Autoriser External AI (runtime)"
+            description={
+              buildAllowsExternalAI
+                ? isDev
+                  ? "Ce build autorise External AI en dev (runtime implicitement autorisé)."
+                  : "Active/désactive le flag runtime. Un rechargement est nécessaire pour appliquer le changement."
+                : 'Désactivé par ce build (lancer avec VITE_ENABLE_EXTERNAL_AI=1).'
+            }
+            disabled={!buildAllowsExternalAI}
+            icon="🌐"
+          />
+          {externalAIToggleError && <p className="cp-error">{externalAIToggleError}</p>}
+          {!externalAIToggleError && buildAllowsExternalAI && (
+            <p className="cp-helper-text">
+              Clé localStorage: <strong>{EXTERNAL_AI_STORAGE_KEY}</strong>
+            </p>
+          )}
+          {buildAllowsExternalAI && !isDev && (
+            <button className="cp-button secondary" onClick={reloadApp}>
+              🔄 Recharger maintenant
+            </button>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Résumé
- Ajoute des métriques d’observabilité côté frontend dans le QA Monitoring Center (incl. export JSON).
- Instrumente `secureInvoke` pour tracer requêtes, breadcrumbs, erreurs et latence sans exposer les payloads.
- Rend l’IA externe explicitement opt-in (build flag + toggle runtime), avec doc + UI.

## Détails
- QA Monitoring: affichage `monitoring.getMetrics()` + bouton d’export `monitoring.exportMetrics()`.
- `secureInvoke`: `trackRequest()`, breadcrumbs start/success, `trackError()` avec `stage` sur erreurs de validation/invoke.
- Garde-fous: IA externe désactivée par défaut; activation requiert build + localStorage.

## Validation
- COPILOT-XS: Validate ✅
- COPILOT-XS: Test Gate ✅

## Risques / Notes
- Aucun serveur HTTP ajouté (Tauri-only conservé).
- L’export métriques télécharge un fichier local JSON; aucune donnée sensible du payload n’est incluse.