### PR TITLE
Post-merge — Correctifs de revue (observability/AI)

### DIFF
--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -10,7 +10,7 @@ type EnvValue = string | boolean | undefined;
 
 const env = import.meta.env as Record<string, EnvValue>;
 
-function envFlag(key: string): boolean {
+export function envFlag(key: string): boolean {
   const value = env[key];
   if (value === true) return true;
   if (value === false) return false;

--- a/src/features/qa-monitoring/QAMonitoringPage.tsx
+++ b/src/features/qa-monitoring/QAMonitoringPage.tsx
@@ -1012,7 +1012,9 @@ function QAMonitoringPageContent(): JSX.Element {
       a.download = `titane-metrics-${new Date().toISOString()}.json`;
       a.click();
 
-      URL.revokeObjectURL(url);
+      setTimeout(() => {
+        URL.revokeObjectURL(url);
+      }, 100);
     } catch (err) {
       logger.error(
         'Failed to export frontend metrics',

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -1779,14 +1779,14 @@ export async function secureInvoke<T>(
       throw new Error('Fallback response received');
     }
 
-      try {
-        monitoring.addBreadcrumb('secureInvoke success', 'tauri', {
-          command,
-          latencyMs: Date.now() - startedAt,
-        });
-      } catch {
-        // ignore monitoring errors
-      }
+    try {
+      monitoring.addBreadcrumb('secureInvoke success', 'tauri', {
+        command,
+        latencyMs: Date.now() - startedAt,
+      });
+    } catch {
+      // ignore monitoring errors
+    }
 
     return sanitized as T;
   } catch (error) {

--- a/src/ui/pages/ControlPanel/sections/AISection.tsx
+++ b/src/ui/pages/ControlPanel/sections/AISection.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { secureInvoke } from '@/lib/security';
+import { envFlag } from '@/config/featureFlags';
 import { ControlPanelToggle } from '../components/ControlPanelToggle';
 
 interface AIConfig {
@@ -16,21 +17,6 @@ interface AIConfig {
 
 const GEMINI_KEY_SENTINEL = '***MASKED***';
 const EXTERNAL_AI_STORAGE_KEY = 'titane.enable_external_ai';
-
-type EnvValue = string | boolean | undefined;
-
-const env = import.meta.env as Record<string, EnvValue>;
-
-function envFlag(key: string): boolean {
-  const value = env[key];
-  if (value === true) return true;
-  if (value === false) return false;
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    return normalized === '1' || normalized === 'true' || normalized === 'yes';
-  }
-  return false;
-}
 
 const DEFAULT_CONFIG: AIConfig = {
   gemini_api_key: '',
@@ -118,7 +104,7 @@ export const AISection: React.FC = () => {
       setExternalAIToggleError(null);
     } catch {
       setExternalAIToggleError(
-        "Impossible d'accéder au stockage local (localStorage)."
+        "Impossible d’accéder au stockage local (localStorage)."
       );
     }
   }, []);


### PR DESCRIPTION
## Contexte
La PR #20 (Phase 5 — Observability + opt-in IA externe) a été mergée, mais quelques correctifs issus des retours de revue ont été finalisés ensuite.

## Changements
- Exporte `envFlag` dans `featureFlags` et réutilise la fonction dans la section IA (suppression duplication).
- Corrige l’indentation / structure des blocs `try/catch` de monitoring dans `secureInvoke`.
- Retarde `URL.revokeObjectURL` (~100ms) après l’export JSON des métriques pour éviter d’interrompre le téléchargement.
- Ajuste une chaîne UI (apostrophe typographique).

## Validation
- COPILOT-XS Test Gate ✅ (local)

## Notes
- Aucun ajout de serveur HTTP (Tauri-only préservé).
- Pas de données sensibles ajoutées dans l’export métriques.