### PR TITLE
chore(build): Git LFS pour le binaire Node embarqué

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 # ═══════════════════════════════════════════════════════════════════
 # TITANE∞ v∞.40 — Git LFS Configuration
 # ═══════════════════════════════════════════════════════════════════
-
 # 🤖 AI Models (should be excluded from Git entirely - use external storage)
 *.bin filter=lfs diff=lfs merge=lfs -text
 *.gguf filter=lfs diff=lfs merge=lfs -text
@@ -13,13 +12,11 @@
 *.pb filter=lfs diff=lfs merge=lfs -text
 *.h5 filter=lfs diff=lfs merge=lfs -text
 *.model filter=lfs diff=lfs merge=lfs -text
-
 # 📦 Archives (generally should be excluded)
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.tar.gz filter=lfs diff=lfs merge=lfs -text
 *.7z filter=lfs diff=lfs merge=lfs -text
 *.rar filter=lfs diff=lfs merge=lfs -text
-
 # 🎵 Audio files
 *.wav filter=lfs diff=lfs merge=lfs -text
 *.mp3 filter=lfs diff=lfs merge=lfs -text
@@ -27,25 +24,21 @@
 *.ogg filter=lfs diff=lfs merge=lfs -text
 *.m4a filter=lfs diff=lfs merge=lfs -text
 *.aac filter=lfs diff=lfs merge=lfs -text
-
 # 🎥 Video files
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.mov filter=lfs diff=lfs merge=lfs -text
 *.avi filter=lfs diff=lfs merge=lfs -text
 *.mkv filter=lfs diff=lfs merge=lfs -text
-
 # 🖼️ Large images
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.ai filter=lfs diff=lfs merge=lfs -text
 *.xcf filter=lfs diff=lfs merge=lfs -text
-
 # 🚀 Production builds (only if you need to version them)
 # Commented out - prefer excluding from Git entirely
 # *.AppImage filter=lfs diff=lfs merge=lfs -text
 # *.dmg filter=lfs diff=lfs merge=lfs -text
 # *.deb filter=lfs diff=lfs merge=lfs -text
 # *.rpm filter=lfs diff=lfs merge=lfs -text
-
 # ═══════════════════════════════════════════════════════════════════
 # Line Endings (Windows/Unix compatibility)
 # ═══════════════════════════════════════════════════════════════════
@@ -58,6 +51,9 @@
 *.md text eol=lf
 *.css text eol=lf
 *.scss text eol=lf
+
+# 🧰 Toolchain binaries (vendored)
+.tools/node/_extract/**/bin/node filter=lfs diff=lfs merge=lfs -text
 *.html text eol=lf
 *.rs text eol=lf
 *.toml text eol=lf
@@ -65,7 +61,6 @@
 *.yml text eol=lf
 *.sh text eol=lf
 *.py text eol=lf
-
 # ═══════════════════════════════════════════════════════════════════
 # END TITANE∞ .gitattributes
 # ═══════════════════════════════════════════════════════════════════

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TITANE∞ est un **OS cognitif local-first** : votre double numérique évolutif
 - **Node.js:** v20+ (LTS)
 - **Rust:** 1.75+
 - **Tauri CLI:** v2.0+
+- **Git LFS:** requis (certains binaires toolchain sont versionnés via LFS)
 
 ### Installation
 
@@ -36,6 +37,10 @@ TITANE∞ est un **OS cognitif local-first** : votre double numérique évolutif
 # 1. Cloner le repo
 git clone https://github.com/KallokTherok1994/TITANE_INFINITY.git
 cd TITANE_INFINITY
+
+# 1.1 Initialiser Git LFS (recommandé)
+git lfs install
+git lfs pull
 
 # 2. Installer dépendances (pnpm + toolchain incluse au repo)
 export PATH="$PWD/.tools/node/current/bin:$PATH"


### PR DESCRIPTION
## Objectif
Éliminer les warnings GitHub « gros fichier » et éviter de versionner le binaire Node (≈94MB) en blob Git.

## Changements
- Ajoute une règle ciblée dans `.gitattributes` : `.tools/node/_extract/**/bin/node` → `filter=lfs`.
- Remplace le blob Git du binaire Node par un pointeur Git LFS (upload LFS effectué).

## Notes
- Ce commit **ne réécrit pas l’historique** : l’ancien blob peut exister dans les commits passés, mais HEAD utilise désormais LFS.
- Si tu veux un nettoyage complet (suppression du blob de l’historique), on pourra faire une opération dédiée (`git lfs migrate import --everything`) + force-push (à valider explicitement).

## Validation
- Push LFS OK (1 objet, ~98MB).